### PR TITLE
Version bump workflow

### DIFF
--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -1,0 +1,26 @@
+name: "Check PR Label"
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - reopened
+      - labeled
+      - unlabeled
+
+jobs:
+  check-labels:
+    name: "Check PR Labels"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: mheap/github-action-required-labels@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with: # Must have only 1 of the ff label
+          mode: exactly
+          count: 1
+          labels: "major, minor, patch"

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -1,0 +1,22 @@
+name: "Comment on PR Open"
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+
+jobs:
+  add-comment:
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: mshick/add-pr-comment@v2
+        with:
+          message: |
+            Please set a versioning label of either `major`, `minor`, or `patch` to the pull request.
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,6 @@ name: Release zip file
 
 # Which event cause workflow
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - "v*.*.*"
   pull_request: # Merged PRs to main
     branches:
       - main
@@ -18,13 +13,46 @@ permissions:
 
 jobs:
   release-zip:
-    if: github.event_name == 'push' || github.event_name == 'pull_request' && github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: "npm"
+
+      - name: Git config
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+      - name: Apply version bump (major)
+        if: contains(github.event.pull_request.labels.*.name, 'major')
+        run: npm version major
+
+      - name: Apply version bump (minor)
+        if: contains(github.event.pull_request.labels.*.name, 'minor')
+        run: npm version minor
+
+      - name: Apply version bump (patch)
+        if: contains(github.event.pull_request.labels.*.name, 'patch')
+        run: npm version patch
+
+      - name: Git push version bump
+        run: git push origin dev --follow-tags --force
+
+      - name: Generate release tag
+        id: get-version
+        run: |
+          VERSION=$(npm pkg get version)
+          echo "## Current Version: $VERSION"
+          echo ::set-output name=version_tag::$VERSION
+
+      # ------------------------------------------------------ #
       - name: Create dist folder as zip file
         uses: montudor/action-zip@v1
         with:
@@ -44,13 +72,6 @@ jobs:
 
       - name: Display structure of files
         run: ls -R
-
-      - name: Generate release tag
-        id: get-version
-        run: |
-          VERSION=$(cat package.json | jq -r '.version')
-          echo "## Current Version: $VERSION"
-          echo ::set-output name=version_tag::$VERSION
 
       - name: Create release with dist zip
         id: final-release-step


### PR DESCRIPTION
1. `pr-open` - add comment to remind to you to add appropriate version label
2. `pr-label` - checks if only 1 label is set properly
3. `release` - npm version bumping based on label found from PR