### PR TITLE
feat: remove prettier checks on main branch pushes

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,8 +1,6 @@
 name: Check formatting via prettier
 
 on:
-  push:
-    branches: ["main"]
   pull_request:
     branches: ["main"]
 jobs:


### PR DESCRIPTION
- force push aren't allowed anyway
- force pushers 🫣
  - pull request merge commits - already enforced in PR status checks before merging
  - version bump commits - um.... why